### PR TITLE
fix(terraform): Template 변수 불일치 및 MIG 정리 문제 수정

### DIFF
--- a/terraform/environments/gcp/mig.tf
+++ b/terraform/environments/gcp/mig.tf
@@ -92,6 +92,10 @@ resource "google_compute_instance_group_manager" "k3s_workers" {
   zone               = var.zone
   target_size        = var.worker_count
 
+  # Destroy 시 인스턴스 삭제 완료 대기
+  wait_for_instances        = true
+  wait_for_instances_status = "STABLE"
+
   version {
     instance_template = google_compute_instance_template.k3s_worker.id
   }

--- a/terraform/environments/gcp/scripts/k3s-server.sh
+++ b/terraform/environments/gcp/scripts/k3s-server.sh
@@ -19,6 +19,7 @@ GITOPS_REPO_URL="${gitops_repo_url}"
 GITOPS_TARGET_REVISION="${gitops_target_revision}"
 
 # Helm Chart Versions
+ARGOCD_VERSION="${helm_versions.argocd}"
 ISTIO_VERSION="${helm_versions.istio}"
 LOKI_STACK_VERSION="${helm_versions.loki_stack}"
 KUBE_PROMETHEUS_VERSION="${helm_versions.kube_prometheus}"
@@ -87,10 +88,9 @@ kubectl create namespace argocd --dry-run=client -o yaml | kubectl apply -f -
 kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
 kubectl create namespace titanium-prod --dry-run=client -o yaml | kubectl apply -f -
 
-# Install ArgoCD (version pinned for stability)
-ARGOCD_VERSION="v3.2.3"
-log "Installing ArgoCD ${ARGOCD_VERSION}..."
-kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/${ARGOCD_VERSION}/manifests/install.yaml
+# Install ArgoCD
+log "Installing ArgoCD $ARGOCD_VERSION..."
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/$ARGOCD_VERSION/manifests/install.yaml
 
 # Wait for ArgoCD to be ready
 log "Waiting for ArgoCD deployments..."

--- a/terraform/environments/gcp/variables.tf
+++ b/terraform/environments/gcp/variables.tf
@@ -125,12 +125,14 @@ variable "grafana_admin_password" {
 variable "helm_versions" {
   description = "Helm chart versions for installed components"
   type = object({
+    argocd          = string
     istio           = string
     loki_stack      = string
     kube_prometheus = string
     kiali           = string
   })
   default = {
+    argocd          = "v3.2.3"
     istio           = "1.24.2"
     loki_stack      = "2.10.2"
     kube_prometheus = "79.5.0"


### PR DESCRIPTION
## Summary
- `helm_versions` object에 `argocd` 필드 추가하여 ArgoCD 버전 동적 관리
- `k3s-server.sh`에서 하드코딩된 `ARGOCD_VERSION` 제거 및 템플릿 변수로 대체
- MIG에 `wait_for_instances` 설정 추가로 `terraform destroy` 시 인스턴스 삭제 완료 대기

## Changes
| File | Description |
|------|-------------|
| `terraform/environments/gcp/variables.tf` | `helm_versions.argocd` 필드 추가 |
| `terraform/environments/gcp/scripts/k3s-server.sh` | 템플릿 변수 사용으로 변경 |
| `terraform/environments/gcp/mig.tf` | `wait_for_instances = true` 설정 추가 |

## Test plan
- [ ] `terraform validate` 통과 확인
- [ ] `terraform plan` 실행하여 변경사항 검토
- [ ] `terraform apply` 후 ArgoCD 정상 설치 확인
- [ ] `terraform destroy` 시 MIG 인스턴스 정상 삭제 확인

Closes #22