### PR TITLE
fix(test): Monitoring Stack 테스트 대기 시간 증가 (#35)

### DIFF
--- a/terraform/environments/gcp/main.tf
+++ b/terraform/environments/gcp/main.tf
@@ -48,7 +48,7 @@ locals {
   }
 
   # GCP System IP ranges (documented by Google)
-  gcp_iap_cidr          = "35.235.240.0/20"
+  gcp_iap_cidr           = "35.235.240.0/20"
   gcp_health_check_cidrs = ["35.191.0.0/16", "130.211.0.0/22"]
 }
 

--- a/terraform/environments/gcp/mig.tf
+++ b/terraform/environments/gcp/mig.tf
@@ -11,7 +11,7 @@ resource "google_compute_health_check" "k3s_autohealing" {
   unhealthy_threshold = 3
 
   tcp_health_check {
-    port = "10250"  # Kubelet port
+    port = "10250" # Kubelet port
   }
 }
 
@@ -67,7 +67,7 @@ resource "google_compute_instance_template" "k3s_worker" {
   # Spot (Preemptible) VM configuration
   scheduling {
     preemptible                 = var.use_spot_for_workers
-    automatic_restart           = false  # Spot VM은 automatic_restart 불가
+    automatic_restart           = false # Spot VM은 automatic_restart 불가
     on_host_maintenance         = "TERMINATE"
     provisioning_model          = var.use_spot_for_workers ? "SPOT" : "STANDARD"
     instance_termination_action = var.use_spot_for_workers ? "STOP" : null
@@ -103,7 +103,7 @@ resource "google_compute_instance_group_manager" "k3s_workers" {
   # Auto-healing Policy
   auto_healing_policies {
     health_check      = google_compute_health_check.k3s_autohealing.id
-    initial_delay_sec = 300  # k3s 설치 및 Join 대기 시간 (5분)
+    initial_delay_sec = 300 # k3s 설치 및 Join 대기 시간 (5분)
   }
 
   # Update Policy - Rolling update

--- a/terraform/environments/gcp/test/helpers.go
+++ b/terraform/environments/gcp/test/helpers.go
@@ -44,11 +44,11 @@ const (
 	K3sBootstrapTimeout   = 15 * time.Minute
 	DefaultTimeout        = 30 * time.Second
 
-	// Monitoring Stack 재시도 설정 (Issue #27, #29)
-	MonitoringStackInitialWait    = 7 * time.Minute  // Bootstrap 초기 대기
-	MonitoringAppReadyWait        = 5 * time.Minute  // Application Pod Ready 대기 (3분 -> 5분, Loki/Prometheus 초기화 고려)
-	MonitoringHealthCheckRetries  = 6                // Health Check 재시도 횟수 (3 -> 6)
-	MonitoringHealthCheckInterval = 20 * time.Second // Health Check 재시도 간격
+	// Monitoring Stack 재시도 설정 (Issue #27, #29, #35)
+	MonitoringStackInitialWait    = 7 * time.Minute   // Bootstrap 초기 대기
+	MonitoringAppReadyWait        = 10 * time.Minute  // Application Pod Ready 대기 (5분 -> 10분, 리소스 제약 환경 대응 #35)
+	MonitoringHealthCheckRetries  = 12                // Health Check 재시도 횟수 (6 -> 12, 리소스 제약 환경 대응 #35)
+	MonitoringHealthCheckInterval = 20 * time.Second  // Health Check 재시도 간격
 
 	// Application 관련 상수 (Issue #27 - 2차 리뷰)
 	NamespaceProd = "titanium-prod"

--- a/terraform/environments/gcp/variables.tf
+++ b/terraform/environments/gcp/variables.tf
@@ -144,19 +144,19 @@ variable "helm_versions" {
 variable "nodeports" {
   description = "NodePort assignments for services"
   type = object({
-    argocd          = number
-    grafana         = number
-    prometheus      = number
-    kiali           = number
-    istio_http      = number
-    istio_https     = number
+    argocd      = number
+    grafana     = number
+    prometheus  = number
+    kiali       = number
+    istio_http  = number
+    istio_https = number
   })
   default = {
-    argocd          = 30080
-    grafana         = 31300
-    prometheus      = 31090
-    kiali           = 31200
-    istio_http      = 31080
-    istio_https     = 31443
+    argocd      = 30080
+    grafana     = 31300
+    prometheus  = 31090
+    kiali       = 31200
+    istio_http  = 31080
+    istio_https = 31443
   }
 }


### PR DESCRIPTION
## 개요 (Overview)
- Terratest Layer 5 (TestMonitoringStackValidation) 실행 시 리소스 제약으로 인한 Pod Ready 지연 문제 해결
- Issue #35에서 권장한 단기 해결책 Option 2 (대기 시간 증가) 적용

## 주요 변경 사항 (Key Changes)
- `MonitoringAppReadyWait`: 5분 -> 10분으로 증가
- `MonitoringHealthCheckRetries`: 6회 -> 12회로 증가
- Terraform 파일 포맷 정리 (`terraform fmt` 적용)

### 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `terraform/environments/gcp/test/helpers.go` | 대기 시간 및 재시도 횟수 상수 증가 |
| `terraform/environments/gcp/main.tf` | 포맷 정리 (공백 정렬) |
| `terraform/environments/gcp/mig.tf` | 포맷 정리 (주석 앞 공백) |
| `terraform/environments/gcp/variables.tf` | 포맷 정리 (공백 정렬) |

### 변경 영향도
| 항목 | 변경 전 | 변경 후 | 영향 |
|------|---------|---------|------|
| Pod Ready 대기 | 5분 | 10분 | 테스트 안정성 향상 |
| Health Check 재시도 | 6회 (2분) | 12회 (4분) | 일시적 장애 내성 향상 |
| 최대 테스트 시간 | 약 20분 | 약 25분 | 약간 증가 |

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)
- **테스트 시나리오:** Layer 0 정적 검증 테스트 (terraform fmt, validate)
- **검증 결과:**
```
=== RUN   TestTerraformFormat
--- PASS: TestTerraformFormat (0.06s)
=== RUN   TestTerraformValidate
--- PASS: TestTerraformValidate (1.49s)
PASS
ok      github.com/DvwN-Lee/Monitoring-v2/terraform/environments/gcp/test   2.677s
```
- go build 검증 완료: 컴파일 오류 없음

## 연관 이슈 (Linked Issues)
- Closes #35