### PR TITLE
fix(mig): e2 인스턴스 scheduling 설정 및 MIG 타임아웃 문제 해결 (#37)

### DIFF
--- a/terraform/environments/gcp/test/50_monitoring_stack_test.go
+++ b/terraform/environments/gcp/test/50_monitoring_stack_test.go
@@ -21,6 +21,13 @@ func TestMonitoringStackValidation(t *testing.T) {
 	defer terraform.Destroy(t, terraformOptions)
 	terraform.InitAndApply(t, terraformOptions)
 
+	// Issue #37: wait_for_instances=false로 변경됨에 따라
+	// Worker 인스턴스 RUNNING 상태 대기 (MIG 15분 타임아웃 방지)
+	t.Log("Worker 인스턴스 RUNNING 상태 대기 중...")
+	workerNames, err := GetWorkerInstanceNamesWithRetry(t, DefaultClusterName, DefaultProjectID, DefaultZone, DefaultWorkerCount)
+	require.NoError(t, err, "Worker 인스턴스 RUNNING 대기 실패")
+	t.Logf("Worker 인스턴스 RUNNING 확인: %v", workerNames)
+
 	masterPublicIP := terraform.Output(t, terraformOptions, "master_external_ip")
 	waitForK3sCluster(t, masterPublicIP)
 
@@ -30,7 +37,7 @@ func TestMonitoringStackValidation(t *testing.T) {
 	// Monitoring Stack이 완전히 준비될 때까지 단계별 대기 (Issue #27)
 	// 1단계: ArgoCD Application Healthy 대기 (최대 10분)
 	// 2단계: Monitoring Pod Ready 확인 (최대 3분)
-	err := WaitForMonitoringStackReady(t, host)
+	err = WaitForMonitoringStackReady(t, host)
 	require.NoError(t, err, "Monitoring Stack 준비 실패")
 
 	// Monitoring Stack Subtests

--- a/terraform/environments/gcp/variables.tf
+++ b/terraform/environments/gcp/variables.tf
@@ -53,6 +53,12 @@ variable "use_spot_for_workers" {
   default     = true
 }
 
+variable "enable_auto_healing" {
+  description = "Enable auto-healing for worker MIG (disable for test environments)"
+  type        = bool
+  default     = true
+}
+
 variable "master_disk_size" {
   description = "Disk size for master node in GB"
   type        = number


### PR DESCRIPTION
## 개요 (Overview)

GCP e2 인스턴스에서 발생하는 scheduling 설정 오류와 MIG 15분 타임아웃 문제를 해결

## 주요 변경 사항 (Key Changes)

### 1. e2 인스턴스 scheduling 설정 수정 (`mig.tf`)

- **문제**: e2 인스턴스는 non-Spot VM인 경우 `on_host_maintenance=TERMINATE` 미지원
- **해결**: `use_spot_for_workers` 변수에 따라 동적 설정
  ```hcl
  scheduling {
    preemptible         = var.use_spot_for_workers
    automatic_restart   = var.use_spot_for_workers ? false : true
    on_host_maintenance = var.use_spot_for_workers ? "TERMINATE" : "MIGRATE"
    provisioning_model  = var.use_spot_for_workers ? "SPOT" : "STANDARD"
  }
  ```

### 2. MIG wait_for_instances 타임아웃 해결

- **문제**: `wait_for_instances=true` 설정 시 Terraform 15분 타임아웃 초과
- **해결**: 
  - `wait_for_instances=false`로 변경
  - 테스트 코드에서 Worker 인스턴스 RUNNING 상태 대기 로직 구현

### 3. Auto-healing 제어 변수 추가 (`variables.tf`)

```hcl
variable "enable_auto_healing" {
  description = "Enable auto-healing for worker MIG"
  type        = bool
  default     = true
}
```

### 4. 테스트 헬퍼 함수 개선 (`helpers.go`)

- `GetWorkerInstanceNamesWithRetry`: MIG 인스턴스 프로비저닝 대기 (최대 15분)
- `logMIGStatus`: MIG 상태 디버깅 로깅
- `extractJSON`: gcloud WARNING 메시지 필터링

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 테스트 시나리오
- Layer 5 `TestMonitoringStackValidation` 실행

### 검증 결과

| 항목 | 수정 전 | 수정 후 |
|------|--------|--------|
| Worker 인스턴스 상태 | STOPPING (즉시 종료) | **RUNNING** |
| MIG 생성 | 15분 타임아웃 | 정상 완료 |
| e2 scheduling | 오류 발생 | 정상 동작 |

### 테스트 로그 (Worker RUNNING 확인)
```
Worker 인스턴스 RUNNING 확인: [terratest-k3s-worker-gkmk terratest-k3s-worker-z7bf]
```

### 참고
- 테스트는 Application 설정 문제(`JWT_PRIVATE_KEY` Secret 누락)로 인해 Degraded 상태로 종료됨
- 해당 문제는 Issue #39로 별도 추적

## 연관 이슈 (Linked Issues)

- Closes #37
- Related: #39 (Application Secret 누락 문제)