### PR TITLE
fix: PostgreSQL StatefulSet/Service Label 일관성 수정

### DIFF
--- a/k8s-manifests/overlays/gcp/postgres/service.yaml
+++ b/k8s-manifests/overlays/gcp/postgres/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: postgresql-service
   namespace: titanium-prod
+  labels:
+    app: postgresql
+    app.kubernetes.io/name: titanium
+    app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
     app: postgresql

--- a/k8s-manifests/overlays/gcp/postgres/statefulset.yaml
+++ b/k8s-manifests/overlays/gcp/postgres/statefulset.yaml
@@ -3,6 +3,11 @@ kind: StatefulSet
 metadata:
   name: postgresql
   namespace: titanium-prod
+  labels:
+    app: postgresql
+    app.kubernetes.io/name: titanium
+    app.kubernetes.io/managed-by: kustomize
+    version: v1
 spec:
   serviceName: "postgresql-service"
   replicas: 1
@@ -13,6 +18,9 @@ spec:
     metadata:
       labels:
         app: postgresql
+        app.kubernetes.io/name: titanium
+        app.kubernetes.io/managed-by: kustomize
+        version: v1
       annotations:
         sidecar.istio.io/inject: "false"
     spec:


### PR DESCRIPTION
## 개요 (Overview)
PostgreSQL StatefulSet의 Pod Template 및 Service에 Kubernetes 표준 Label을 추가하여 다른 서비스들과 Label 일관성을 확보합니다.

## 주요 변경 사항 (Key Changes)
- `postgres/statefulset.yaml`: metadata 및 Pod Template에 표준 Label 추가
- `postgres/service.yaml`: metadata에 표준 Label 추가

### 추가된 Label
| Label | 값 | 적용 대상 |
|-------|-----|----------|
| `app.kubernetes.io/name` | titanium | StatefulSet, Service, Pod |
| `app.kubernetes.io/managed-by` | kustomize | StatefulSet, Service, Pod |
| `version` | v1 | Pod Template |

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 문제 상황
- Kiali Dashboard에서 PostgreSQL Workload "Missing Version" Warning 발생
- 다른 서비스들과 Label 구조 불일치

### 근본 원인
- PostgreSQL은 `overlays/gcp/postgres/`에 별도 정의
- `base/kustomization.yaml`의 `commonLabels` 미상속
- overlay의 `labels` 변환은 Pod Template에 미적용

### 검증 방법
```bash
# ArgoCD Sync 후 확인
kubectl get pods -n titanium-prod -o custom-columns='NAME:.metadata.name,VERSION:.metadata.labels.version'

# Kiali Dashboard Warning 해소 확인
```

## 연관 이슈 (Linked Issues)
- Closes #48