### PR TITLE
fix(monitoring): Promtail pipeline을 regex 기반으로 변경하여 Logs Volume 오류 수정

### DIFF
--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -116,16 +116,11 @@ resource "kubernetes_manifest" "loki_stack_application" {
                         replacement: /var/log/pods/*$1/*.log
                     pipeline_stages:
                       - cri: {}
-                      - json:
-                          expressions:
-                            level: level
-                            msg: message
-                            timestamp: timestamp
+                      # Plain Text 로그에서 Level 추출 (INFO:, ERROR:, WARNING:, DEBUG: 패턴)
+                      - regex:
+                          expression: '^(?P<level>[A-Z]+):'
                       - labels:
                           level:
-                      - timestamp:
-                          source: timestamp
-                          format: RFC3339Nano
               resources:
                 limits:
                   cpu: 200m


### PR DESCRIPTION
## 개요 (Overview)
- Grafana Explore에서 Loki Logs Volume 시각화 오류 수정
- Promtail pipeline을 JSON 파싱에서 regex 파싱으로 변경

## 주요 변경 사항 (Key Changes)
- `terraform/modules/monitoring/main.tf`: promtail pipeline_stages 수정
  - 기존: JSON 파싱으로 `level` 필드 추출 시도
  - 변경: regex 패턴 `^(?P<level>[A-Z]+):`으로 Plain Text 로그에서 level 추출
- 불필요한 timestamp 파싱 스테이지 제거 (CRI 파서가 기본 처리)

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)
**문제:**
```
Failed to load log volume for this query
parse error at line 1, col 84: syntax error: unexpected IDENTIFIER
```

**원인:**
- 애플리케이션 로그가 Plain Text 형식 (`INFO: ...`)
- JSON 파싱 실패로 `level` 레이블 미생성
- Grafana Logs Volume 쿼리 `sum by (level) (count_over_time(...))` 파싱 오류

**검증 계획:**
1. ArgoCD에서 loki-stack Application Sync
2. Promtail Pod 재시작 확인
3. Grafana Explore에서 Logs Volume 정상 렌더링 확인

## 연관 이슈 (Linked Issues)
- Closes #50