### PR TITLE
fix(blog): PostgreSQL categories 테이블 시퀀스 동기화 오류 수정

### DIFF
--- a/blog-service/app/database.py
+++ b/blog-service/app/database.py
@@ -98,6 +98,11 @@ class BlogDatabase:
                     (3, 'Test', 'test', '#757575')
                 ''')
 
+            # Synchronize categories_id_seq with existing data
+            await conn.execute(
+                "SELECT setval('categories_id_seq', COALESCE((SELECT MAX(id) FROM categories), 1))"
+            )
+
             # Create posts table
             await conn.execute('''
                 CREATE TABLE IF NOT EXISTS posts (

--- a/k8s-manifests/overlays/gcp/postgres/configmap.yaml
+++ b/k8s-manifests/overlays/gcp/postgres/configmap.yaml
@@ -31,6 +31,9 @@ data:
         (3, 'Test', 'test')
     ON CONFLICT (id) DO NOTHING;
 
+    -- Synchronize categories_id_seq with existing data
+    SELECT setval('categories_id_seq', COALESCE((SELECT MAX(id) FROM categories), 1));
+
     -- Initialize posts table for blog-service
     CREATE TABLE IF NOT EXISTS posts (
         id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## 개요 (Overview)
- Blog Post 생성 시 새 카테고리를 추가하면 `UniqueViolationError` 발생하는 문제 해결
- 원인: 명시적 ID로 기본 카테고리 INSERT 시 PostgreSQL SERIAL 시퀀스가 자동 업데이트되지 않음

## 주요 변경 사항 (Key Changes)
- `k8s-manifests/overlays/gcp/postgres/configmap.yaml`: init.sql에 시퀀스 동기화 SQL 추가
- `blog-service/app/database.py`: `_initialize_postgres_schema` 메서드에 시퀀스 동기화 로직 추가 (조건문 외부에서 항상 실행)

```sql
SELECT setval('categories_id_seq', COALESCE((SELECT MAX(id) FROM categories), 1));
```

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 수정 전 (Before)
```sql
postgres=# SELECT MAX(id) FROM categories;
 max 
-----
   3
(1 row)

postgres=# SELECT last_value FROM categories_id_seq;
 last_value 
------------
          2
(1 row)

-- 새 카테고리 INSERT 시도
postgres=# INSERT INTO categories (name, slug) VALUES ('NewCategory', 'new-category');
ERROR:  duplicate key value violates unique constraint "categories_pkey"
DETAIL:  Key (id)=(3) already exists.
```

### 수정 후 (After)
```sql
-- setval() 실행 후
postgres=# SELECT setval('categories_id_seq', COALESCE((SELECT MAX(id) FROM categories), 1));
 setval 
--------
      3
(1 row)

postgres=# SELECT last_value FROM categories_id_seq;
 last_value 
------------
          3
(1 row)

-- 새 카테고리 INSERT 성공
postgres=# INSERT INTO categories (name, slug) VALUES ('NewCategory', 'new-category') RETURNING id;
 id 
----
  4
(1 row)
```

### 코드 동작 확인
- `database.py`의 시퀀스 동기화는 `if count == 0:` 블록 **외부**에 위치
- 카테고리 존재 여부와 관계없이 스키마 초기화 시 항상 시퀀스 동기화 실행

## 연관 이슈 (Linked Issues)
- Closes #52