### PR TITLE
refactor(monitoring): Monitoring Stack 보안 및 구조 개선

### DIFF
--- a/k8s-manifests/overlays/gcp/monitoring/kustomization.yaml
+++ b/k8s-manifests/overlays/gcp/monitoring/kustomization.yaml
@@ -2,7 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # ArgoCD AppProject
+  - monitoring-project.yaml
+  # Kubernetes Resources
   - grafana-secret.yaml
+  - network-policy.yaml
+  # ArgoCD Applications
   - prometheus-app.yaml
   - loki-app.yaml
   - promtail-app.yaml

--- a/k8s-manifests/overlays/gcp/monitoring/loki-app.yaml
+++ b/k8s-manifests/overlays/gcp/monitoring/loki-app.yaml
@@ -6,7 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: monitoring
   source:
     repoURL: https://grafana.github.io/helm-charts
     chart: loki

--- a/k8s-manifests/overlays/gcp/monitoring/monitoring-project.yaml
+++ b/k8s-manifests/overlays/gcp/monitoring/monitoring-project.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: monitoring
+  namespace: argocd
+spec:
+  description: Monitoring Stack Project (Prometheus, Loki, Promtail)
+  # Source Repository 제한
+  sourceRepos:
+    - https://prometheus-community.github.io/helm-charts
+    - https://grafana.github.io/helm-charts
+  # 배포 대상 Cluster/Namespace 제한
+  destinations:
+    - namespace: monitoring
+      server: https://kubernetes.default.svc
+  # Cluster Resource 허용 목록
+  clusterResourceWhitelist:
+    - group: ""
+      kind: Namespace
+  # Namespace Resource 허용 (모든 Resource 허용)
+  namespaceResourceWhitelist:
+    - group: "*"
+      kind: "*"

--- a/k8s-manifests/overlays/gcp/monitoring/network-policy.yaml
+++ b/k8s-manifests/overlays/gcp/monitoring/network-policy.yaml
@@ -1,0 +1,61 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: monitoring-network-policy
+  namespace: monitoring
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # monitoring Namespace 내부 통신 허용
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+    # titanium-prod Namespace에서 Prometheus scrape 허용
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: titanium-prod
+      ports:
+        - protocol: TCP
+          port: 9090
+        - protocol: TCP
+          port: 3100
+    # kube-system에서 Node Exporter 접근 허용
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+  egress:
+    # DNS 허용 (kube-dns)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # monitoring Namespace 내부 통신 허용
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+    # titanium-prod Namespace로 메트릭 수집 허용
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: titanium-prod
+    # Kubernetes API Server 접근 허용
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443

--- a/k8s-manifests/overlays/gcp/monitoring/prometheus-app.yaml
+++ b/k8s-manifests/overlays/gcp/monitoring/prometheus-app.yaml
@@ -6,7 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: monitoring
   source:
     repoURL: https://prometheus-community.github.io/helm-charts
     chart: kube-prometheus-stack
@@ -29,8 +29,7 @@ spec:
             serviceMonitorSelectorNilUsesHelmValues: false
             podMonitorSelectorNilUsesHelmValues: false
           service:
-            type: NodePort
-            nodePort: 30090
+            type: ClusterIP
 
         # Grafana 설정
         grafana:
@@ -40,8 +39,7 @@ spec:
             userKey: admin-user
             passwordKey: admin-password
           service:
-            type: NodePort
-            nodePort: 30300
+            type: ClusterIP
           persistence:
             enabled: true
             size: 5Gi
@@ -57,8 +55,7 @@ spec:
         alertmanager:
           enabled: true
           service:
-            type: NodePort
-            nodePort: 30093
+            type: ClusterIP
 
         # Node Exporter
         nodeExporter:

--- a/k8s-manifests/overlays/gcp/monitoring/promtail-app.yaml
+++ b/k8s-manifests/overlays/gcp/monitoring/promtail-app.yaml
@@ -6,7 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:
-  project: default
+  project: monitoring
   source:
     repoURL: https://grafana.github.io/helm-charts
     chart: promtail
@@ -94,6 +94,7 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - ServerSideApply=true
     retry:
       limit: 5
       backoff:


### PR DESCRIPTION
## 개요 (Overview)
PR #55 Code Review에서 도출된 Monitoring Stack 보안 및 구조 개선 사항을 적용합니다. NodePort 제거, Network Policy 적용, ArgoCD Project 분리 등을 통해 보안성과 구조적 일관성을 강화합니다.

## 주요 변경 사항 (Key Changes)

### 보안 개선
- `prometheus-app.yaml`: NodePort -> ClusterIP 전환 (Prometheus, Grafana, AlertManager)
- `network-policy.yaml`: monitoring Namespace에 NetworkPolicy 적용
  - monitoring 내부 통신 허용
  - titanium-prod에서 메트릭 수집 허용
  - DNS 및 Kubernetes API 접근 허용

### 구조 개선
- `monitoring-project.yaml`: ArgoCD AppProject 분리
  - Source Repository 제한 (prometheus-community, grafana Helm charts만 허용)
  - Destination 제한 (monitoring Namespace만 허용)
- `promtail-app.yaml`: syncOptions에 `ServerSideApply=true` 추가 (일관성)
- 모든 Application에서 `project: default` -> `project: monitoring` 변경

### 스크립트 안정성 개선
- `deploy-monitoring.sh`: 
  - `sleep 10` 대신 Application 생성 확인 Loop 사용
  - Promtail 동기화 대기 추가
  - AppProject 및 NetworkPolicy 배포 단계 추가

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 변경 파일 목록
```
k8s-manifests/
├── overlays/gcp/monitoring/
│   ├── kustomization.yaml        (수정)
│   ├── monitoring-project.yaml   (신규)
│   ├── network-policy.yaml       (신규)
│   ├── prometheus-app.yaml       (수정)
│   ├── loki-app.yaml             (수정)
│   └── promtail-app.yaml         (수정)
└── scripts/
    └── deploy-monitoring.sh      (수정)
```

### 접근 방법 변경
NodePort 제거로 인해 외부 접근은 port-forward를 통해서만 가능:
```bash
# Grafana
kubectl port-forward svc/prometheus-grafana -n monitoring 3000:80

# Prometheus
kubectl port-forward svc/prometheus-kube-prometheus-prometheus -n monitoring 9090:9090

# AlertManager
kubectl port-forward svc/prometheus-kube-prometheus-alertmanager -n monitoring 9093:9093
```

## 연관 이슈 (Linked Issues)
- Closes #56