### PR TITLE
fix(istio): Istio sidecar 초기화 실패로 인한 Pod Ready 지연 해결

### DIFF
--- a/k8s-manifests/base/api-gateway-deployment.yaml
+++ b/k8s-manifests/base/api-gateway-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           httpGet:
             path: /health
             port: http
-          initialDelaySeconds: 5
+          initialDelaySeconds: 15
           periodSeconds: 5
         startupProbe:
           httpGet:

--- a/k8s-manifests/base/blog-service-deployment.yaml
+++ b/k8s-manifests/base/blog-service-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           httpGet:
             path: /health
             port: http
-          initialDelaySeconds: 5
+          initialDelaySeconds: 15
           periodSeconds: 10
         startupProbe:
           httpGet:

--- a/k8s-manifests/overlays/gcp/kustomization.yaml
+++ b/k8s-manifests/overlays/gcp/kustomization.yaml
@@ -63,6 +63,8 @@ patches:
         template:
           metadata:
             annotations:
+              # Istio sidecar 초기화 완료 후 Application 시작 (Issue #60)
+              proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
               sidecar.istio.io/proxyCPU: "50m"
               sidecar.istio.io/proxyCPULimit: "200m"
               sidecar.istio.io/proxyMemory: "64Mi"


### PR DESCRIPTION
## 개요 (Overview)
- Istio sidecar가 초기화되기 전에 Application container가 시작되어 mTLS 통신 실패 및 Pod가 `1/2 Running` 상태에서 멈추는 문제 해결
- ArgoCD titanium-prod Application이 `Degraded` 상태에서 `Healthy`로 전환되지 않는 근본 원인 수정

## 주요 변경 사항 (Key Changes)

### 1. `holdApplicationUntilProxyStarts` annotation 추가
- **파일**: `k8s-manifests/overlays/gcp/kustomization.yaml`
- **변경**: 모든 Deployment에 `proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'` annotation 추가
- **효과**: Istio sidecar proxy가 완전히 초기화된 후에만 Application container 시작

### 2. Readiness Probe 초기 지연 시간 증가
- **파일**: `k8s-manifests/base/api-gateway-deployment.yaml`, `k8s-manifests/base/blog-service-deployment.yaml`
- **변경**: `readinessProbe.initialDelaySeconds` 5초 -> 15초
- **효과**: sidecar 초기화 및 mTLS 연결 수립을 위한 충분한 시간 확보

### 3. 수정하지 않은 파일
| 파일 | 이유 |
|------|------|
| `user-service-deployment.yaml` | `initialDelaySeconds`가 이미 10초 |
| `auth-service-deployment.yaml` | `initialDelaySeconds`가 이미 10초 |
| `peer-authentication.yaml` | STRICT 모드 유지 (보안 요구사항) |

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 근본 원인 분석
1. **Race Condition**: Application container가 Istio sidecar보다 먼저 시작
2. **mTLS 실패**: sidecar 미초기화 상태에서 PeerAuthentication STRICT 모드로 인한 통신 차단
3. **Readiness 실패**: 짧은 `initialDelaySeconds`로 인해 sidecar 준비 전 health check 시작

### 검증 결과
```bash
# Kustomize 빌드 검증 - annotation 적용 확인
$ kubectl kustomize k8s-manifests/overlays/gcp/ | grep -A5 "proxy.istio.io/config"
        proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
        sidecar.istio.io/proxyCPU: 50m
        sidecar.istio.io/proxyCPULimit: 200m
        sidecar.istio.io/proxyMemory: 64Mi
        sidecar.istio.io/proxyMemoryLimit: 256Mi
```

### 예상 결과
- 모든 Pod가 `2/2 Running` 상태로 전환
- ArgoCD Application이 `Healthy` 상태
- Terratest `ApplicationPodsReady`, `ApplicationHealth` 테스트 통과

## Rollback 계획
문제 발생 시:
1. `kustomization.yaml`에서 `proxy.istio.io/config` annotation 제거
2. `initialDelaySeconds`를 5로 복원
3. ArgoCD sync 트리거

## 연관 이슈 (Linked Issues)
- Closes #60