### PR TITLE
fix(monitoring): Envoy stats PodMonitor targetPort 설정 수정

### DIFF
--- a/k8s-manifests/overlays/gcp/istio/servicemonitors.yaml
+++ b/k8s-manifests/overlays/gcp/istio/servicemonitors.yaml
@@ -32,7 +32,7 @@ spec:
     - key: app
       operator: Exists
   podMetricsEndpoints:
-  - port: http-envoy-prom
+  - targetPort: 15090
     interval: 30s
     path: /stats/prometheus
     relabelings:


### PR DESCRIPTION
## 개요 (Overview)
- Prometheus가 Envoy stats 타겟을 찾지 못하는 문제 해결 (0/9 up 상태)
- PodMonitor 설정에서 존재하지 않는 named port 대신 포트 번호를 직접 지정

## 주요 변경 사항 (Key Changes)
- `k8s-manifests/overlays/gcp/istio/servicemonitors.yaml`:
  - `port: http-envoy-prom` (이름 기반) -> `targetPort: 15090` (포트 번호 직접 지정)
  - Istio sidecar에는 named port가 정의되어 있지 않으므로, targetPort를 사용하여 Envoy 메트릭 포트(15090)를 직접 참조

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)
- **원인:** Istio envoy sidecar container에 `http-envoy-prom`이라는 named port가 없음
- **결과:** Prometheus ServiceDiscovery가 해당 포트를 찾지 못해 스크레이핑 실패
- **검증 방법:**
  1. ArgoCD sync 후 Prometheus `/targets` 페이지 확인
  2. `podMonitor/titanium-prod/prod-envoy-stats-monitor/0` 상태가 `9/9 up`인지 확인
  3. `up{job=~".*envoy.*"}` PromQL 쿼리로 메트릭 수집 확인

## 연관 이슈 (Linked Issues)
- Closes #63