### PR TITLE
fix(istio): istio-proxy CSR 서명 실패 해결

### DIFF
--- a/k8s-manifests/overlays/gcp/kustomization.yaml
+++ b/k8s-manifests/overlays/gcp/kustomization.yaml
@@ -64,7 +64,12 @@ patches:
           metadata:
             annotations:
               # Istio sidecar 초기화 완료 후 Application 시작 (Issue #60)
-              proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
+              # CSR 서명 실패 시 graceful shutdown 지원 (Issue #68)
+              proxy.istio.io/config: |
+                holdApplicationUntilProxyStarts: true
+                terminationDrainDuration: 30s
+                proxyMetadata:
+                  EXIT_ON_ZERO_ACTIVE_CONNECTIONS: "true"
               sidecar.istio.io/proxyCPU: "50m"
               sidecar.istio.io/proxyCPULimit: "200m"
               sidecar.istio.io/proxyMemory: "64Mi"


### PR DESCRIPTION
## 개요 (Overview)

titanium-prod namespace의 Application Pod들이 istio-proxy CSR 서명 실패로 인해 CrashLoopBackOff 상태가 발생하는 문제를 해결합니다.

## 주요 변경 사항 (Key Changes)

- `proxy.istio.io/config`: JSON 형식에서 YAML multiline 형식으로 변경
- `terminationDrainDuration: 30s`: Pod 종료 시 연결 drain 대기 시간 추가
- `EXIT_ON_ZERO_ACTIVE_CONNECTIONS: "true"`: 활성 연결이 없을 때 빠른 종료 설정

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 문제 상황

istio-proxy가 Istiod에 CSR 전송 시 연결 실패 발생:

```
error: failed to sign CSR: create certificate: rpc error: code = Unavailable
desc = "transport: Error while dialing: dial tcp 10.43.173.99:15012: connect: connection refused"
```

영향받은 Service:
| Service | Status |
|---------|--------|
| API Gateway | CrashLoopBackOff |
| Auth Service | CrashLoopBackOff |
| User Service | 1/2 Running |
| Blog Service | CrashLoopBackOff |
| Redis | CrashLoopBackOff |

### 검증 방법

ArgoCD Sync 후 다음 명령어로 확인:

```bash
# Pod 상태 확인
kubectl get pods -n titanium-prod

# istio-proxy 로그에서 CSR 성공 확인
kubectl logs -n titanium-prod deploy/prod-api-gateway-deployment -c istio-proxy | grep -E "(CSR|certificate)"

# Prometheus targets 확인
curl -s 'http://34.50.8.19:31090/api/v1/targets' | jq '[.data.activeTargets[] | select(.health=="up")] | length'
```

## 연관 이슈 (Linked Issues)

Closes #68