### PR TITLE
fix(network): NetworkPolicy에 Istiod egress 규칙 추가

### DIFF
--- a/k8s-manifests/overlays/gcp/network-policies.yaml
+++ b/k8s-manifests/overlays/gcp/network-policies.yaml
@@ -58,6 +58,19 @@ spec:
       ports:
         - protocol: TCP
           port: 8005
+    # Istiod로의 통신 허용 (Istio sidecar CSR 서명, XDS 구성)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+          podSelector:
+            matchLabels:
+              app: istiod
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15010
     # DNS 조회 허용
     - to:
         - namespaceSelector: {}
@@ -115,6 +128,19 @@ spec:
       ports:
         - protocol: TCP
           port: 6379
+    # Istiod로의 통신 허용 (Istio sidecar CSR 서명, XDS 구성)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+          podSelector:
+            matchLabels:
+              app: istiod
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15010
     # DNS 조회 허용
     - to:
         - namespaceSelector: {}
@@ -175,6 +201,19 @@ spec:
       ports:
         - protocol: TCP
           port: 6379
+    # Istiod로의 통신 허용 (Istio sidecar CSR 서명, XDS 구성)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+          podSelector:
+            matchLabels:
+              app: istiod
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15010
     # DNS 조회 허용
     - to:
         - namespaceSelector: {}
@@ -224,6 +263,19 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+    # Istiod로의 통신 허용 (Istio sidecar CSR 서명, XDS 구성)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+          podSelector:
+            matchLabels:
+              app: istiod
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15010
     # DNS 조회 허용
     - to:
         - namespaceSelector: {}
@@ -260,6 +312,19 @@ spec:
         - protocol: TCP
           port: 6379
   egress:
+    # Istiod로의 통신 허용 (Istio sidecar CSR 서명, XDS 구성)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+          podSelector:
+            matchLabels:
+              app: istiod
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15010
     # DNS 조회만 허용
     - to:
         - namespaceSelector: {}
@@ -296,6 +361,19 @@ spec:
         - protocol: TCP
           port: 5432
   egress:
+    # Istiod로의 통신 허용 (Istio sidecar CSR 서명, XDS 구성)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+          podSelector:
+            matchLabels:
+              app: istiod
+      ports:
+        - protocol: TCP
+          port: 15012
+        - protocol: TCP
+          port: 15010
     # DNS 조회만 허용
     - to:
         - namespaceSelector: {}


### PR DESCRIPTION
## 개요 (Overview)

모든 NetworkPolicy에 Istiod(istio-system)로의 egress 규칙을 추가하여 istio-proxy CSR 서명 실패 문제를 해결합니다.

## 주요 변경 사항 (Key Changes)

- `api-gateway-network-policy`: Istiod egress 규칙 추가
- `auth-service-network-policy`: Istiod egress 규칙 추가
- `user-service-network-policy`: Istiod egress 규칙 추가
- `blog-service-network-policy`: Istiod egress 규칙 추가
- `redis-network-policy`: Istiod egress 규칙 추가
- `postgresql-network-policy`: Istiod egress 규칙 추가

추가된 egress 규칙:
```yaml
- to:
    - namespaceSelector:
        matchLabels:
          kubernetes.io/metadata.name: istio-system
      podSelector:
        matchLabels:
          app: istiod
  ports:
    - protocol: TCP
      port: 15012  # XDS/CSR
    - protocol: TCP
      port: 15010  # Telemetry
```

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 문제 상황

NetworkPolicy egress 규칙에 Istiod가 누락되어 istio-proxy가 CSR 서명을 받지 못함:

```
error: failed to sign CSR: create certificate: rpc error: code = Unavailable
desc = "transport: Error while dialing: dial tcp 10.43.173.99:15012: connect: connection refused"
```

### 검증 결과

kubectl patch로 동일한 규칙 적용 후 Pod 상태가 CrashLoopBackOff에서 Running으로 전환됨:

```
NAME                                            READY   STATUS    RESTARTS   AGE
prod-api-gateway-deployment-5858756b-fznfc      2/2     Running   0          69s
prod-auth-service-deployment-758848bcc7-4hvdk   2/2     Running   263        13h
prod-blog-service-deployment-bf446f7cd-p775c    2/2     Running   263        13h
prod-user-service-deployment-8b7b95b78-g57wk    2/2     Running   263        13h
```

## 연관 이슈 (Linked Issues)

Closes #70