### PR TITLE
feat(scripts): Kiali 자동 접속 스크립트 추가

### DIFF
--- a/scripts/README-kiali-access.md
+++ b/scripts/README-kiali-access.md
@@ -27,7 +27,7 @@
 
 ---
 
-### 2. kiali-connect-advanced.sh (고급 버전) ⭐ 추천
+### 2. kiali-connect-advanced.sh (고급 버전) - 추천
 
 **특징**:
 - IP 사용 이력 추적 (~/.kiali-ip-history)
@@ -80,7 +80,7 @@ $ ./scripts/kiali-connect.sh
 현재 IP: 14.35.115.202
 방화벽 규칙 확인 중...
 현재 IP를 방화벽 규칙에 추가 중...
-✓ 방화벽 규칙 업데이트 완료
+[OK] 방화벽 규칙 업데이트 완료
 
 === Kiali 접속 정보 ===
 URL: http://34.50.8.19:31200/kiali
@@ -100,7 +100,7 @@ $ ./scripts/kiali-connect-advanced.sh
 방화벽 규칙 업데이트 중...
 이전: 112.218.39.251/32,64.236.160.193/32,14.35.115.100/32
 이후: 112.218.39.251/32,14.35.115.202/32
-✓ 방화벽 규칙 업데이트 완료
+[OK] 방화벽 규칙 업데이트 완료
 
 === Kiali 접속 정보 ===
 URL: http://34.50.8.19:31200/kiali
@@ -131,48 +131,57 @@ source ~/.bashrc  # 또는 source ~/.zshrc
 kiali
 ```
 
-## 설정 커스터마이징
+## 환경 변수를 통한 설정 커스터마이징
 
-스크립트 상단의 변수를 수정하여 설정을 변경할 수 있습니다.
+스크립트는 환경 변수를 통해 설정을 변경할 수 있습니다.
 
-### kiali-connect-advanced.sh 설정
+### 지원하는 환경 변수
+
+| 환경 변수 | 기본값 | 설명 |
+|-----------|--------|------|
+| `GCP_PROJECT_ID` | `titanium-k3s-1765951764` | GCP 프로젝트 ID |
+| `KIALI_FIREWALL_RULE` | `titanium-k3s-allow-dashboards` | 방화벽 규칙 이름 |
+| `KIALI_MASTER_IP` | `34.50.8.19` | Kubernetes Master Node IP |
+| `KIALI_PORT` | `31200` | Kiali NodePort |
+| `KIALI_BASE_IP` | (없음) | 항상 유지할 고정 IP (CIDR 형식) |
+| `KIALI_MAX_IPS` | `10` | 최대 허용 IP 개수 (고급 버전만) |
+
+### 사용 예시
 
 ```bash
-# 프로젝트 ID
-PROJECT_ID="titanium-k3s-1765951764"
+# 환경 변수로 설정 오버라이드
+export KIALI_BASE_IP="112.218.39.251/32"
+export KIALI_MAX_IPS=5
+./scripts/kiali-connect-advanced.sh
 
-# 방화벽 규칙 이름
-FIREWALL_RULE="titanium-k3s-allow-dashboards"
+# 또는 한 줄로 실행
+KIALI_BASE_IP="112.218.39.251/32" ./scripts/kiali-connect-advanced.sh
+```
 
-# Kiali 접속 정보
-MASTER_IP="34.50.8.19"
-KIALI_PORT="31200"
+### 영구 설정 (선택)
 
-# 항상 유지할 고정 IP (쉼표로 구분)
-BASE_ALLOWED_IP="112.218.39.251/32"
-
-# 최대 허용 IP 개수 (기본: 10)
-MAX_ALLOWED_IPS=10
-
-# IP 기록 파일 경로
-IP_HISTORY_FILE="${HOME}/.kiali-ip-history"
+```bash
+# ~/.bashrc 또는 ~/.zshrc에 추가
+export KIALI_BASE_IP="YOUR_STATIC_IP/32"
+export GCP_PROJECT_ID="your-project-id"
 ```
 
 ## 문제 해결
 
 ### 1. "현재 IP를 확인할 수 없습니다" 오류
 
-**원인**: 인터넷 연결 문제 또는 ifconfig.me 서비스 장애
+**원인**: 인터넷 연결 문제 또는 모든 IP 확인 서비스 장애
 
 **해결**:
 ```bash
-# 수동으로 IP 확인
+# 수동으로 IP 확인 (여러 서비스 시도)
 curl ifconfig.me
 curl icanhazip.com
-
-# 스크립트 수정 (다른 서비스 사용)
-# CURRENT_IP=$(curl -s icanhazip.com)
+curl ipinfo.io/ip
+curl api.ipify.org
 ```
+
+스크립트는 자동으로 4개의 서비스를 순차적으로 시도합니다.
 
 ### 2. 권한 오류
 
@@ -230,9 +239,9 @@ gcloud iam roles create KialiFirewallManager \
 
 고급 버전은 최대 10개 IP만 유지하여 방화벽 규칙 비대화 방지
 
-### 3. BASE_ALLOWED_IP 관리
+### 3. 환경 변수를 통한 설정
 
-고정 IP가 있다면 `BASE_ALLOWED_IP`에 추가하여 항상 접속 가능하도록 설정
+민감한 IP 정보는 스크립트에 하드코딩하지 않고 환경 변수로 관리
 
 ### 4. 로그 확인
 

--- a/scripts/kiali-connect-advanced.sh
+++ b/scripts/kiali-connect-advanced.sh
@@ -2,23 +2,54 @@
 
 set -e
 
-PROJECT_ID="titanium-k3s-1765951764"
-FIREWALL_RULE="titanium-k3s-allow-dashboards"
-MASTER_IP="34.50.8.19"
-KIALI_PORT="31200"
-BASE_ALLOWED_IP="112.218.39.251/32"  # 항상 유지할 IP
-MAX_ALLOWED_IPS=10  # 최대 허용 IP 개수
+# 설정 (환경 변수로 오버라이드 가능)
+PROJECT_ID="${GCP_PROJECT_ID:-titanium-k3s-1765951764}"
+FIREWALL_RULE="${KIALI_FIREWALL_RULE:-titanium-k3s-allow-dashboards}"
+MASTER_IP="${KIALI_MASTER_IP:-34.50.8.19}"
+KIALI_PORT="${KIALI_PORT:-31200}"
+BASE_ALLOWED_IP="${KIALI_BASE_IP:-}"  # 항상 유지할 IP (환경 변수로 설정)
+MAX_ALLOWED_IPS="${KIALI_MAX_IPS:-10}"  # 최대 허용 IP 개수
 
 # IP 기록 파일 경로
 IP_HISTORY_FILE="${HOME}/.kiali-ip-history"
+
+# IP 확인 함수 (fallback 지원)
+get_current_ip() {
+    local ip=""
+    local services=("ifconfig.me" "icanhazip.com" "ipinfo.io/ip" "api.ipify.org")
+
+    for service in "${services[@]}"; do
+        ip=$(curl -s --connect-timeout 5 "$service" 2>/dev/null)
+        if [[ "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "$ip"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# IP 형식 검증 함수
+validate_ip() {
+    local ip="$1"
+    if [[ "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        return 0
+    fi
+    return 1
+}
 
 echo "=== Kiali 자동 접속 스크립트 (고급) ==="
 
 # 1. 현재 IP 확인
 echo "현재 IP 확인 중..."
-CURRENT_IP=$(curl -s ifconfig.me)
+CURRENT_IP=$(get_current_ip)
 if [ -z "$CURRENT_IP" ]; then
     echo "ERROR: 현재 IP를 확인할 수 없습니다."
+    echo "네트워크 연결을 확인하세요."
+    exit 1
+fi
+
+if ! validate_ip "$CURRENT_IP"; then
+    echo "ERROR: 유효하지 않은 IP 형식: $CURRENT_IP"
     exit 1
 fi
 echo "현재 IP: $CURRENT_IP"
@@ -29,31 +60,49 @@ if [ ! -f "$IP_HISTORY_FILE" ]; then
     touch "$IP_HISTORY_FILE"
 fi
 
+# 임시 파일 생성 (mktemp 사용)
+TEMP_FILE=$(mktemp)
+trap "rm -f $TEMP_FILE" EXIT
+
 # 기존 기록에서 현재 IP 제거 (중복 방지)
-grep -v "^${CURRENT_IP}," "$IP_HISTORY_FILE" > "${IP_HISTORY_FILE}.tmp" 2>/dev/null || true
-mv "${IP_HISTORY_FILE}.tmp" "$IP_HISTORY_FILE"
+grep -v "^${CURRENT_IP}," "$IP_HISTORY_FILE" > "$TEMP_FILE" 2>/dev/null || true
+mv "$TEMP_FILE" "$IP_HISTORY_FILE"
 
 # 현재 IP 추가
 echo "${CURRENT_IP},${CURRENT_TIMESTAMP}" >> "$IP_HISTORY_FILE"
 
 # 3. 현재 방화벽 규칙 확인
 echo "방화벽 규칙 확인 중..."
-CURRENT_RANGES=$(gcloud compute firewall-rules describe $FIREWALL_RULE \
-    --project=$PROJECT_ID \
+CURRENT_RANGES=$(gcloud compute firewall-rules describe "$FIREWALL_RULE" \
+    --project="$PROJECT_ID" \
     --format="value(sourceRanges)")
 
 # 4. 허용할 IP 목록 생성
-# - BASE_ALLOWED_IP는 항상 포함
+# - BASE_ALLOWED_IP는 항상 포함 (설정된 경우)
 # - 최근 사용한 IP들을 최대 MAX_ALLOWED_IPS개까지 포함
 echo "허용할 IP 목록 생성 중..."
 
 # 최근 IP들 추출 (최신순 정렬)
-RECENT_IPS=$(sort -t',' -k2 -rn "$IP_HISTORY_FILE" | head -n $MAX_ALLOWED_IPS | cut -d',' -f1)
+# 임시 파일 생성 (mktemp 사용)
+SORTED_FILE=$(mktemp)
+trap "rm -f $TEMP_FILE $SORTED_FILE" EXIT
+
+sort -t',' -k2 -rn "$IP_HISTORY_FILE" | head -n "$MAX_ALLOWED_IPS" | cut -d',' -f1 > "$SORTED_FILE"
+RECENT_IPS=$(cat "$SORTED_FILE")
 
 # 새로운 IP 범위 생성
-NEW_RANGES="$BASE_ALLOWED_IP"
+if [ -n "$BASE_ALLOWED_IP" ]; then
+    NEW_RANGES="$BASE_ALLOWED_IP"
+else
+    NEW_RANGES=""
+fi
+
 for ip in $RECENT_IPS; do
-    NEW_RANGES="${NEW_RANGES},${ip}/32"
+    if [ -n "$NEW_RANGES" ]; then
+        NEW_RANGES="${NEW_RANGES},${ip}/32"
+    else
+        NEW_RANGES="${ip}/32"
+    fi
 done
 
 # 중복 제거
@@ -65,21 +114,24 @@ if [ "$CURRENT_RANGES" != "$NEW_RANGES" ]; then
     echo "이전: $CURRENT_RANGES"
     echo "이후: $NEW_RANGES"
 
-    gcloud compute firewall-rules update $FIREWALL_RULE \
-        --project=$PROJECT_ID \
+    gcloud compute firewall-rules update "$FIREWALL_RULE" \
+        --project="$PROJECT_ID" \
         --source-ranges="$NEW_RANGES" \
         --quiet
 
-    echo "✓ 방화벽 규칙 업데이트 완료"
+    echo "[OK] 방화벽 규칙 업데이트 완료"
 else
-    echo "✓ 방화벽 규칙 변경 불필요"
+    echo "[OK] 방화벽 규칙 변경 불필요"
 fi
 
 # 6. IP 기록 정리 (오래된 기록 삭제)
 # 30일 이상 된 기록 삭제
 CUTOFF_TIME=$((CURRENT_TIMESTAMP - 30*24*60*60))
-awk -F',' -v cutoff=$CUTOFF_TIME '$2 >= cutoff' "$IP_HISTORY_FILE" > "${IP_HISTORY_FILE}.tmp"
-mv "${IP_HISTORY_FILE}.tmp" "$IP_HISTORY_FILE"
+CLEANUP_FILE=$(mktemp)
+trap "rm -f $TEMP_FILE $SORTED_FILE $CLEANUP_FILE" EXIT
+
+awk -F',' -v cutoff=$CUTOFF_TIME '$2 >= cutoff' "$IP_HISTORY_FILE" > "$CLEANUP_FILE"
+mv "$CLEANUP_FILE" "$IP_HISTORY_FILE"
 
 # 7. Kiali URL 출력 및 브라우저 열기
 KIALI_URL="http://${MASTER_IP}:${KIALI_PORT}/kiali"


### PR DESCRIPTION
## 개요

동적 IP 환경에서 Kiali 접속 시 매번 방화벽 규칙을 수동으로 업데이트해야 하는 불편함을 해결하기 위한 자동화 스크립트를 추가했습니다.

## 주요 변경 사항

### 스크립트 파일

- `scripts/kiali-connect.sh`: 기본 자동 접속 스크립트
  - 현재 공인 IP 자동 확인 (ifconfig.me 사용)
  - GCP 방화벽 규칙 자동 업데이트
  - Kiali URL 브라우저 자동 실행
  
- `scripts/kiali-connect-advanced.sh`: 고급 버전
  - IP 사용 이력 추적 (~/.kiali-ip-history)
  - 최근 10개 IP만 유지하여 방화벽 규칙 최적화
  - 30일 이상 된 IP 기록 자동 삭제
  - 중복 IP 제거 및 정렬

- `scripts/README-kiali-access.md`: 종합 사용 가이드
  - 스크립트 사용 방법 및 예시
  - 설정 커스터마이징 가이드
  - 문제 해결 방법
  - 보안 고려사항

### 기술적 의사결정

**IP 확인 방법**: ifconfig.me 사용
- 신뢰성 높은 공개 IP 조회 서비스
- curl로 간단히 조회 가능

**방화벽 규칙 관리**: gcloud CLI 사용
- GCP Firewall Rules API 활용
- 기존 IP 목록에 현재 IP 추가하는 방식

**고급 버전의 IP 관리 전략**:
- 최대 10개 IP 유지로 방화벽 규칙 비대화 방지
- BASE_ALLOWED_IP (112.218.39.251/32) 항상 유지
- 타임스탬프 기반 오래된 IP 자동 정리

## 문제 해결 및 테스트 결과

### 테스트 시나리오

1. **기본 스크립트 실행 테스트**
   === Kiali 자동 접속 스크립트 ===
현재 IP 확인 중...
현재 IP: 112.218.39.251
방화벽 규칙 확인 중...
✓ 현재 IP(112.218.39.251)가 이미 허용되어 있습니다.

=== Kiali 접속 정보 ===
URL: http://34.50.8.19:31200/kiali

브라우저를 여는 중...

=== 접속 완료 ===
   
   **결과**:
   

2. **방화벽 규칙 업데이트 확인**
   112.150.249.93/32;112.218.39.251/32
   
   **결과**:
   
   현재 IP가 정상적으로 추가되었습니다.

3. **Kiali 접속 테스트**
   HTTP Status: 200
   
   **결과**:
   
   Kiali API가 정상적으로 응답했습니다.

4. **고급 스크립트 실행 테스트**
   === Kiali 자동 접속 스크립트 (고급) ===
현재 IP 확인 중...
현재 IP: 112.218.39.251
방화벽 규칙 확인 중...
허용할 IP 목록 생성 중...
방화벽 규칙 업데이트 중...
이전: 112.150.249.93/32;112.218.39.251/32
이후: 112.150.249.93/32,112.218.39.251/32
✓ 방화벽 규칙 업데이트 완료

=== Kiali 접속 정보 ===
URL: http://34.50.8.19:31200/kiali
현재 허용된 IP 개수: 2

브라우저를 여는 중...

=== 접속 완료 ===

팁: IP 기록은 ~/.kiali-ip-history에 저장됩니다.
팁: 최대 10개의 최근 IP가 유지됩니다.
   
   **결과**:
   
   
   IP 정렬 및 최적화가 정상적으로 동작했습니다.

5. **IP 기록 파일 확인**
   112.150.249.93,1769010706
112.218.39.251,1769043191
   
   **결과**:
   
   IP와 타임스탬프가 정상적으로 기록되었습니다.

### 트러블슈팅

**문제**: macOS 환경에서 브라우저 자동 실행 테스트
**해결**: `open` 명령 사용으로 Safari/Chrome 자동 실행 확인

## 연관 이슈

Closes #72

## 사용 방법

자세한 사용 방법은 `scripts/README-kiali-access.md` 참조

**빠른 시작**:
=== Kiali 자동 접속 스크립트 ===
현재 IP 확인 중...
현재 IP: 112.218.39.251
방화벽 규칙 확인 중...
✓ 현재 IP(112.218.39.251)가 이미 허용되어 있습니다.

=== Kiali 접속 정보 ===
URL: http://34.50.8.19:31200/kiali

브라우저를 여는 중...

=== 접속 완료 ===
=== Kiali 자동 접속 스크립트 (고급) ===
현재 IP 확인 중...
현재 IP: 112.218.39.251
방화벽 규칙 확인 중...
허용할 IP 목록 생성 중...
방화벽 규칙 업데이트 중...
이전: 112.150.249.93/32;112.218.39.251/32
이후: 112.150.249.93/32,112.218.39.251/32
✓ 방화벽 규칙 업데이트 완료

=== Kiali 접속 정보 ===
URL: http://34.50.8.19:31200/kiali
현재 허용된 IP 개수: 2

브라우저를 여는 중...

=== 접속 완료 ===

팁: IP 기록은 ~/.kiali-ip-history에 저장됩니다.
팁: 최대 10개의 최근 IP가 유지됩니다.