### PR TITLE
fix(network): Blog Service에서 Auth Service로의 NetworkPolicy 규칙 추가

### DIFF
--- a/k8s-manifests/overlays/gcp/network-policies.yaml
+++ b/k8s-manifests/overlays/gcp/network-policies.yaml
@@ -82,7 +82,7 @@ spec:
           port: 53
 ---
 # auth-service NetworkPolicy
-# - Ingress: api-gateway에서만 수신
+# - Ingress: api-gateway, blog-service에서 수신
 # - Egress: user-service, Redis로 송신
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -100,6 +100,9 @@ spec:
         - podSelector:
             matchLabels:
               app: api-gateway
+        - podSelector:
+            matchLabels:
+              app: blog-service
       ports:
         - protocol: TCP
           port: 8002
@@ -226,7 +229,7 @@ spec:
 ---
 # blog-service NetworkPolicy
 # - Ingress: api-gateway에서만 수신
-# - Egress: PostgreSQL로 송신
+# - Egress: PostgreSQL, auth-service로 송신
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -263,6 +266,14 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+    # auth-service로 송신 (JWT 토큰 검증)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: auth-service
+      ports:
+        - protocol: TCP
+          port: 8002
     # Istiod로의 통신 허용 (Istio sidecar CSR 서명, XDS 구성)
     - to:
         - namespaceSelector:


### PR DESCRIPTION
## 개요 (Overview)

Blog Service의 인증 API(포스트 생성/수정/삭제)에서 발생하던 502 Bad Gateway 오류 해결을 위해 NetworkPolicy 규칙 추가.

## 주요 변경 사항 (Key Changes)

- `auth-service NetworkPolicy`: ingress 규칙에 blog-service 추가
  - Blog Service에서 JWT 토큰 검증 요청 수신 허용
- `blog-service NetworkPolicy`: egress 규칙에 auth-service (port 8002) 추가
  - Auth Service `/verify` endpoint로의 통신 허용

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 문제 원인

- Blog Service의 인증 middleware가 JWT 토큰 검증을 위해 Auth Service 호출 필요
- 기존 NetworkPolicy에서 해당 통신 경로 누락으로 502 Bad Gateway 발생

### 변경 내용

```diff
# Auth Service ingress
- from: api-gateway
+ from: api-gateway, blog-service

# Blog Service egress  
+ to: auth-service (port 8002)
```

### 검증 방법

**1. NetworkPolicy 적용 후 Connectivity 테스트**

```bash
# Blog Service Pod에서 Auth Service로 직접 통신 테스트
kubectl exec -n titanium-prod deploy/blog-service -- \
  curl -s -o /dev/null -w "%{http_code}" http://auth-service:8002/health

# 예상 결과: 200 (변경 전: connection timeout 또는 refused)
```

**2. E2E API 테스트**

```bash
# Port-forward 설정
kubectl port-forward -n titanium-prod svc/prod-auth-service 18002:8002 &
kubectl port-forward -n titanium-prod svc/prod-blog-service 18005:8005 &

# 로그인 및 토큰 획득
TOKEN=$(curl -s -X POST http://localhost:18002/login \
  -H "Content-Type: application/json" \
  -d '{"username": "e2e_test_user", "password": "TestPass123@"}' | jq -r '.token')

# 포스트 생성 테스트 (인증 필요 API)
curl -X POST http://localhost:18005/blog/api/posts \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"title": "NetworkPolicy Test", "content": "<p>Test content</p>", "category_name": "technology"}'

# 예상 결과: 201 Created (변경 전: 502 Bad Gateway)
```

**3. NetworkPolicy 규칙 확인**

```bash
# Auth Service ingress 규칙에 blog-service 포함 확인
kubectl get networkpolicy auth-service-network-policy -n titanium-prod -o yaml | \
  grep -A5 "from:"

# Blog Service egress 규칙에 auth-service 포함 확인  
kubectl get networkpolicy blog-service-network-policy -n titanium-prod -o yaml | \
  grep -A10 "egress:"
```

### 예상 결과

| 테스트 항목 | 변경 전 | 변경 후 |
|------------|--------|--------|
| Blog -> Auth connectivity | timeout/refused | 200 OK |
| POST /blog/api/posts | 502 Bad Gateway | 201 Created |
| PUT /blog/api/posts/{id} | 502 Bad Gateway | 200 OK |
| DELETE /blog/api/posts/{id} | 502 Bad Gateway | 204 No Content |

## 연관 이슈 (Linked Issues)

Closes #74