### PR TITLE
fix(argocd): App of Apps 패턴 Child Application 로딩 수정

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - infrastructure
+  - applications


### PR DESCRIPTION
## 개요 (Overview)
- App of Apps 패턴에서 child application들이 ArgoCD에 로드되지 않는 문제 수정
- apps 디렉토리에 kustomization.yaml이 없어서 하위 디렉토리의 Application manifest가 무시됨

## 주요 변경 사항 (Key Changes)
- `apps/kustomization.yaml`: infrastructure와 applications 디렉토리를 resources로 포함하는 Kustomization 파일 추가

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)
- **문제 원인:** ArgoCD Directory source는 기본적으로 root level의 YAML만 스캔하므로, 하위 디렉토리의 manifest를 찾지 못함
- **수정 전:** root-app만 표시 (1개)
- **수정 후:** root-app + child app 7개 (총 8개) 예상
  - root-app
  - istio-base
  - istiod
  - istio-ingressgateway
  - kube-prometheus-stack
  - loki-stack
  - kiali
  - titanium-prod

**검증 방법:**
```bash
# SSH로 master node 접속 후 확인
gcloud compute ssh ubuntu@titanium-k3s-master --zone=asia-northeast3-a --project=titanium-k3s-20260123 \
  --command="sudo kubectl get app -n argocd"
```

## 연관 이슈 (Linked Issues)
- Closes #81