### PR TITLE
fix(deployment): kube-prometheus-stack chart 버전 및 titanium-prod kustomization 오류 수정

### DIFF
--- a/apps/infrastructure/kube-prometheus-stack.yaml
+++ b/apps/infrastructure/kube-prometheus-stack.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     chart: kube-prometheus-stack
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: "68.2.3"
+    targetRevision: "79.5.0"
     helm:
       releaseName: prometheus
       values: |

--- a/k8s-manifests/overlays/gcp/kustomization.yaml
+++ b/k8s-manifests/overlays/gcp/kustomization.yaml
@@ -31,10 +31,6 @@ resources:
   # Reference: https://istio.io/latest/docs/ops/integrations/prometheus/
   # - application-servicemonitors.yaml
 
-# Strategic merge patches
-patchesStrategicMerge:
-  - istio/kiali-service-patch.yaml
-
 # Patches for GCP environment
 patches:
   # Secret은 Terraform kubernetes module에서 관리


### PR DESCRIPTION
## 개요 (Overview)

클라우드 배포 테스트 중 발견된 두 가지 Application 배포 오류 수정

## 주요 변경 사항 (Key Changes)

### 1. kube-prometheus-stack Chart 버전 업데이트
- **파일:** `apps/infrastructure/kube-prometheus-stack.yaml`
- **변경:** `targetRevision: "68.2.3" -> "79.5.0"`
- **사유:** Chart version 68.2.3이 Helm repository에 존재하지 않음

### 2. titanium-prod Kiali Service Patch 제거
- **파일:** `k8s-manifests/overlays/gcp/kustomization.yaml`
- **변경:** `patchesStrategicMerge` 섹션 제거
- **사유:** 
  - Kiali는 별도 kiali Application(sync-wave 1)으로 관리됨
  - titanium-prod Application(sync-wave 4) 빌드 시점에 kiali service 참조 불가능
  - NodePort 설정은 kiali Application manifest의 postRenderers로 처리

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 오류 1: kube-prometheus-stack ComparisonError

**발생 오류:**
```
Error: chart "kube-prometheus-stack" version "68.2.3" not found 
in https://prometheus-community.github.io/helm-charts repository
```

**영향:**
- kube-prometheus-stack Application 배포 실패
- Prometheus, Grafana Service 미생성

**해결:**
- Helm repository 최신 stable 버전(79.5.0) 확인 후 적용
- ArgoCD가 자동으로 chart를 pull하여 배포 가능

### 오류 2: titanium-prod ComparisonError

**발생 오류:**
```
Error: no matches for Id Service.v1.[noGrp]/kiali.istio-system; 
failed to find unique target for patch Service.v1.[noGrp]/kiali.istio-system
```

**영향:**
- titanium-prod Application 배포 실패
- 전체 Application Pod 미생성

**해결:**
- Kustomization build 시점에 필요하지 않은 kiali service patch 제거
- Kiali는 Infrastructure Application으로 별도 관리되므로 patch 불필요

### 예상 배포 결과

PR Merge 후 ArgoCD가 자동으로 sync하여 다음 결과 예상:
- kube-prometheus-stack: Synced/Healthy 상태, Prometheus/Grafana Pod 생성
- titanium-prod: Synced/Healthy 상태, Application Pod 생성

## 연관 이슈 (Linked Issues)

- Closes #86
