### PR TITLE
fix(secret): Secret patch 적용하여 JWT 키 문제 해결

### DIFF
--- a/k8s-manifests/overlays/gcp/kustomization.yaml
+++ b/k8s-manifests/overlays/gcp/kustomization.yaml
@@ -33,7 +33,11 @@ resources:
 
 # Patches for GCP environment
 patches:
-  # Secret은 Terraform kubernetes module에서 관리
+  # Secret 패치 (JWT 키 및 민감 정보)
+  - path: secret-patch.yaml
+    target:
+      kind: Secret
+      name: app-secrets
 
   # Remove SQLite PVC from user-service deployment
   - path: patches/user-service-deployment-patch.yaml


### PR DESCRIPTION
## 개요 (Overview)

auth-service CrashLoopBackOff 오류 수정 - Secret patch가 Kustomization에 포함되지 않아 placeholder JWT 키가 배포되던 문제를 해결했습니다.

## 주요 변경 사항 (Key Changes)

- `k8s-manifests/overlays/gcp/kustomization.yaml`: `patches` 섹션에 `secret-patch.yaml` 추가
  - `secret-patch.yaml`을 Strategic Merge Patch로 적용하여 base Secret의 placeholder JWT 키를 실제 RSA 키로 교체
  - `target.kind: Secret`, `target.name: app-secrets` 지정으로 정확한 리소스 타겟팅

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

**발견된 문제:**
- auth-service Pod: 1/2 Ready, CrashLoopBackOff 상태
- 오류 메시지: `ValueError: Unable to load PEM file. MalformedFraming`
- auth_service.py:22에서 JWT_PRIVATE_KEY 로드 실패

**근본 원인:**
- GCP 환경에 배포된 Secret(`prod-app-secrets`)의 JWT 키가 placeholder 값으로 설정됨
  ```yaml
  JWT_PRIVATE_KEY: cGxhY2Vob2xkZXItcHJpdmF0ZS1rZXk=  # "placeholder-private-key"
  JWT_PUBLIC_KEY: cGxhY2Vob2xkZXItcHVibGljLWtleQ==   # "placeholder-public-key"
  ```
- `secret-patch.yaml`에 실제 RSA 키가 정의되어 있으나, `kustomization.yaml`의 `patches:` 섹션에 포함되지 않아 패치가 적용되지 않음
- Base Secret만 배포되고, GCP overlay의 실제 값이 덮어씌워지지 않음

**해결 방법:**
- `kustomization.yaml`의 `patches:` 섹션에 Secret patch 추가
- Kustomize가 base Secret에 `secret-patch.yaml`의 실제 JWT 키를 merge하도록 설정

**검증 결과:**
```bash
# Kustomize build 테스트
kubectl kustomize k8s-manifests/overlays/gcp | grep -A 10 "kind: Secret"

# Secret data 확인 - JWT 키가 실제 RSA 키로 패치됨
JWT_PRIVATE_KEY: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0t... (2048-bit RSA Private Key)
JWT_PUBLIC_KEY: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0... (RSA Public Key)
```

**예상 효과:**
- auth-service Pod가 정상적으로 JWT 키를 로드하여 2/2 Ready 상태로 전환
- auth-service가 정상적으로 토큰 생성 및 검증 수행

## 연관 이슈 (Linked Issues)

Fixes #<issue-number>