### PR TITLE
fix(istio): Gateway mTLS 통신 문제 해결

### DIFF
--- a/k8s-manifests/overlays/gcp/istio/authorization-policy.yaml
+++ b/k8s-manifests/overlays/gcp/istio/authorization-policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-ingress-gateway
+  namespace: titanium-prod
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        namespaces: ["istio-system"]
+        principals: ["cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"]
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-within-namespace
+  namespace: titanium-prod
+spec:
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        namespaces: ["titanium-prod"]

--- a/k8s-manifests/overlays/gcp/istio/gateway.yaml
+++ b/k8s-manifests/overlays/gcp/istio/gateway.yaml
@@ -36,7 +36,7 @@ spec:
   hosts:
   - "*"
   gateways:
-  - prod-titanium-gateway
+  - titanium-gateway
   http:
   # Blog routes
   - match:

--- a/k8s-manifests/overlays/gcp/kustomization.yaml
+++ b/k8s-manifests/overlays/gcp/kustomization.yaml
@@ -26,6 +26,7 @@ resources:
   - istio/peer-authentication.yaml
   - istio/peer-authentication-databases.yaml
   - istio/destination-rules.yaml
+  - istio/authorization-policy.yaml
   - istio/servicemonitors.yaml
   # Application ServiceMonitors (currently disabled)
   # Reason: Istio mTLS STRICT mode blocks Prometheus scraping from outside mesh


### PR DESCRIPTION
## 개요 (Overview)
Istio Ingress Gateway에서 Backend Service로의 mTLS 통신 실패 문제를 해결합니다. Gateway 이름 불일치 및 Cross-namespace 인증 설정 부재로 인해 모든 HTTP 요청이 503 에러를 반환하는 문제를 수정합니다.

## 주요 변경 사항 (Key Changes)
- `gateway.yaml`: VirtualService의 Gateway 참조 수정 (`prod-titanium-gateway` -> `titanium-gateway`)
- `authorization-policy.yaml`: Cross-namespace mTLS 인증을 위한 AuthorizationPolicy 추가
  - istio-system namespace의 Ingress Gateway에서 titanium-prod namespace로의 접근 허용
  - titanium-prod namespace 내부 트래픽 허용 정책 추가
- `kustomization.yaml`: 새로 생성된 authorization-policy.yaml 리소스 등록

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

### 근본 원인 분석
1. **Gateway 이름 불일치**: VirtualService가 존재하지 않는 `prod-titanium-gateway`를 참조하여 라우팅 실패
2. **Cross-namespace mTLS 인증 실패**: istio-system의 Gateway가 titanium-prod의 Service에 연결 시 인증 실패

### 해결 방법
1. VirtualService의 Gateway 참조를 실제 Gateway 이름(`titanium-gateway`)으로 수정
2. AuthorizationPolicy를 통해 Cross-namespace 통신 명시적 허용:
   - Ingress Gateway ServiceAccount 기반 인증
   - Namespace 내부 트래픽 허용

### 검증 계획
배포 후 다음 테스트를 통해 검증 필요:
```bash
# Gateway 연결 테스트
curl -k https://GATEWAY_IP:30444/blog/

# E2E 테스트 실행
k6 run --insecure-skip-tls-verify tests/e2e/e2e-test.js
```

## 연관 이슈 (Linked Issues)
Closes #2