### PR TITLE
fix(k8s): base kustomization commonLabels를 labels로 전환

### DIFF
--- a/k8s-manifests/base/kustomization.yaml
+++ b/k8s-manifests/base/kustomization.yaml
@@ -19,10 +19,12 @@ resources:
 - configmap.yaml
 - secret.yaml
 
-# 기본 라벨만 간단히 적용
-commonLabels:
-  app.kubernetes.io/name: titanium
-  app.kubernetes.io/managed-by: kustomize
+# 기본 라벨 적용 (commonLabels deprecated -> labels 전환)
+labels:
+  - pairs:
+      app.kubernetes.io/name: titanium
+      app.kubernetes.io/managed-by: kustomize
+    includeSelectors: true
 
 commonAnnotations:
   titanium.io/environment: base


### PR DESCRIPTION
## 개요 (Overview)

`k8s-manifests/base/kustomization.yaml`에서 deprecated된 `commonLabels`를 `labels` 필드로 전환합니다.

## 주요 변경 사항 (Key Changes)

- `k8s-manifests/base/kustomization.yaml`: `commonLabels`를 `labels` + `includeSelectors: true`로 전환
- `includeSelectors: true` 지정으로 기존 `commonLabels`와 동일하게 `selector.matchLabels`에도 label 주입 유지

## 문제 해결 및 테스트 결과 (Problem Solving & Verification)

- **테스트 시나리오:** 변경 전후 `kustomize build` 출력 비교
- **검증 결과:**
  - `diff` 결과 출력 없음 (변경 전후 동일한 YAML 생성 확인)
  - deprecation warning 해소 확인:
    - 변경 전: `Warning: 'commonLabels' is deprecated. Please use 'labels' instead.`
    - 변경 후: warning 없음